### PR TITLE
✨ Support for project-type endpoint filters and includes

### DIFF
--- a/freshbooks/api/resource.py
+++ b/freshbooks/api/resource.py
@@ -86,7 +86,7 @@ class Resource:
         query_string = ""
         if builders:
             for builder in builders:
-                query_string += builder.build()
+                query_string += builder.build(self.__class__.__name__)
         if query_string:
             query_string = "?" + query_string[1:]
         return query_string

--- a/freshbooks/builders/__init__.py
+++ b/freshbooks/builders/__init__.py
@@ -1,4 +1,4 @@
 class Builder:
 
-    def build(self) -> str:  # pragma: no cover
+    def build(self, resource_name: str) -> str:  # pragma: no cover
         raise NotImplementedError

--- a/freshbooks/builders/filter.py
+++ b/freshbooks/builders/filter.py
@@ -119,6 +119,25 @@ class FilterBuilder(Builder):
         self._filters.append(("like", field, value))
         return self
 
+    def date_time(self, field: str, value: Union[str, datetime]) -> Builder:
+        """Filters for entries that come before or after a particular time, as specified
+        by the field. Eg. "updated_since" on Time Entries will return time entries updated
+        after the provided time.
+
+        The url parameter must be in ISO 8601 format (eg. 2010-10-17T05:45:53Z)
+
+        Args:
+            field: The API response field to filter on
+            value: The datetime, or ISO 8601 format string value
+
+        Returns:
+            The FilterBuilder instance
+        """
+        if isinstance(value, datetime):
+            value = value.isoformat()
+        self._filters.append(("date_time", field, value))
+        return self
+
     def between(self, field: str, min: Optional[Any] = None, max: Optional[Any] = None) -> Builder:
         """Filters results where the provided field is between two values.
 
@@ -168,7 +187,7 @@ class FilterBuilder(Builder):
             return value.isoformat()
         return value
 
-    def build(self) -> str:
+    def build(self, resource_name: Optional[str] = None) -> str:
         """Builds the query string parameters from the FilterBuilder.
 
         Returns:
@@ -181,6 +200,6 @@ class FilterBuilder(Builder):
             if filter_type == "in":
                 for val in value:
                     query_string = f"{query_string}&search[{field}][]={val}"
-            if filter_type == "bool":
+            if filter_type in ["bool", "date_time"]:
                 query_string = f"{query_string}&{field}={value}"
         return query_string

--- a/freshbooks/builders/includes.py
+++ b/freshbooks/builders/includes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from freshbooks.builders import Builder
 
@@ -40,7 +40,7 @@ class IncludesBuilder(Builder):
         self._includes.append(key)
         return self
 
-    def build(self) -> str:
+    def build(self, resource_name: Optional[str] = None) -> str:
         """Builds the query string parameters from the IncludesBuilder.
 
         Returns:
@@ -48,5 +48,8 @@ class IncludesBuilder(Builder):
         """
         query_string = ""
         for key in self._includes:
-            query_string = f"{query_string}&include[]={key}"
+            if not resource_name or resource_name in ["AccountingResource", "EventsResource"]:
+                query_string = f"{query_string}&include[]={key}"
+            else:
+                query_string = f"{query_string}&{key}=true"
         return query_string

--- a/freshbooks/builders/paginator.py
+++ b/freshbooks/builders/paginator.py
@@ -108,7 +108,7 @@ class PaginateBuilder(Builder):
             return self
         return self._per_page
 
-    def build(self) -> str:
+    def build(self, resource_name: Optional[str] = None) -> str:
         """Builds the query string parameters from the PaginateBuilder.
 
         Returns:

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -118,12 +118,30 @@ class TestFilter:
 
         assert filter.build() == "&search[start_date]=2020-10-17"
 
+    def test_date_time_string(self):
+        filter = FilterBuilder()
+        filter.date_time("updated_since", "2020-10-17T13:14:07")
+
+        assert filter.build() == "&updated_since=2020-10-17T13:14:07"
+
+    def test_date_time_datetime(self):
+        filter = FilterBuilder()
+        filter.date_time("updated_since", datetime(year=2020, month=10, day=17, hour=13, minute=14, second=7))
+
+        assert filter.build() == "&updated_since=2020-10-17T13:14:07"
+
 
 class TestInclude:
 
-    def test_boolean_true(self):
+    def test_accounting_include(self):
         includes = IncludesBuilder()
         includes.include("late_reminders")
 
-        assert includes.build() == "&include[]=late_reminders"
+        assert includes.build("AccountingResource") == "&include[]=late_reminders"
         assert str(includes) == "IncludesBuilder(&include[]=late_reminders)"
+
+    def test_project_include(self):
+        includes = IncludesBuilder()
+        includes.include("include_overdue_fees")
+
+        assert includes.build("ProjectResource") == "&include_overdue_fees=true"


### PR DESCRIPTION
# Purpose

Project-type endpoints (projects, timetracking, comments) have "Datetime"
filters in their list calls, and have a slightly different includes structure.