### PR TITLE
🐛 Properly handle project errors with message key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Properly handle some project error messages
+
 ## 1.2.1
 
 - Improved error messages on authorization failures

--- a/freshbooks/api/projects.py
+++ b/freshbooks/api/projects.py
@@ -39,8 +39,8 @@ class ProjectsBaseResource(Resource):
             for error_key in errors:  # could be reversed(errors) after dropping 3.7
                 details.append({error_key: errors[error_key]})
                 message = f"Error: {error_key} {errors[error_key]}"
-        else:
-            message = error_response.get("error", "Unknown error")
+        elif error_response.get("error"):
+            message = error_response["error"]
         return message, code, details
 
     def _request(self, url: str, method: str, data: Optional[dict] = None) -> Any:

--- a/tests/fixtures/get_project_response__no_auth.json
+++ b/tests/fixtures/get_project_response__no_auth.json
@@ -1,0 +1,3 @@
+{
+    "message": "The server could not verify that you are authorized to access the URL requested. You either supplied the wrong credentials (e.g. a bad password), or your browser doesn't understand how to supply the credentials required."
+}

--- a/tests/test_projects_resource.py
+++ b/tests/test_projects_resource.py
@@ -68,6 +68,27 @@ class TestProjectsResources:
         assert httpretty.last_request().querystring == expected_params
 
     @httpretty.activate
+    def test_get_project__no_auth(self):
+        project_id = 654321
+        url = "{}/projects/business/{}/project/{}".format(API_BASE_URL, self.business_id, project_id)
+        httpretty.register_uri(
+            httpretty.GET,
+            url,
+            body=json.dumps(get_fixture("get_project_response__no_auth")),
+            status=401
+        )
+
+        try:
+            self.freshBooksClient.projects.get(self.business_id, project_id)
+        except FreshBooksError as e:
+            assert str(e) == ("The server could not verify that you are authorized to access the URL "
+                              "requested. You either supplied the wrong credentials (e.g. a bad "
+                              "password), or your browser doesn't understand how to supply the "
+                              "credentials required.")
+            assert e.status_code == 401
+            assert e.error_code is None
+
+    @httpretty.activate
     def test_get_project__not_found(self):
         project_id = 654321
         url = "{}/projects/business/{}/project/{}".format(API_BASE_URL, self.business_id, project_id)


### PR DESCRIPTION
# Purpose

Project resources can return a 'message', an 'error', or a dictionary of error. We were overwriting the 'message' ones.
